### PR TITLE
Add zhzhuang-zju to the security groups

### DIFF
--- a/security-team/security-groups.md
+++ b/security-team/security-groups.md
@@ -18,10 +18,11 @@ cncf-karmada-security@lists.cncf.io
 
 Owners:
 
-- [wangzefeng@huawei.com](mailto:wangzefeng@huawei.com)
-- [renhongcai@huawei.com](mailto:renhongcai@huawei.com)
+- Zefeng Wang([@Kevin Wang](https://github.com/kevin-wangzefeng)), [wangzefeng@huawei.com](mailto:wangzefeng@huawei.com)
+- Hongcai Ren([@RainbowMango](https://github.com/rainbowmango)), [renhongcai@huawei.com](mailto:renhongcai@huawei.com)
 
 Members:
 
-- [wangzefeng@huawei.com](mailto:wangzefeng@huawei.com)
-- [renhongcai@huawei.com](mailto:renhongcai@huawei.com)
+- Zefeng Wang([@Kevin Wang](https://github.com/kevin-wangzefeng)), [wangzefeng@huawei.com](mailto:wangzefeng@huawei.com)
+- Hongcai Ren([@RainbowMango](https://github.com/rainbowmango)), [renhongcai@huawei.com](mailto:renhongcai@huawei.com)
+- Zhuang Zhang([@zhzhuang-zju](https://github.com/zhzhuang-zju)), [guyue0864@gmail.com](mailto:guyue0864@gmail.com)


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind cleanup
/kind deprecation
/kind documentation
/kind failing-test
/kind flake

-->

**What this PR does / why we need it**:
As the reviewer/member of the community, I took an active and initiative role in participating in the security maintenance of the community, analyzing and resolving multiple security issues to ensure the safety of the community. Below is a list of my relevant work:

- add `trivy` to CI to detect vulnerabilities in container images and dependencies.( https://github.com/karmada-io/karmada/pull/4123 ， https://github.com/karmada-io/karmada/pull/4184)
- Adding TLS Certificate Authentication to gRPC (https://github.com/karmada-io/karmada/issues/5041)
- Enhancement of Karmada maturity based on Clomonitor check sets (https://github.com/karmada-io/karmada/issues/5048)
- Set MinVersion to VersionTLS13 for tlsconfig to fix CVE-2016-2183 (https://github.com/karmada-io/karmada/issues/4191)
- minimize the RBAC permissions for the pull mode cluster (https://github.com/karmada-io/karmada/pull/5793)
- Redact sensitive information from the karmadactl init command output (https://github.com/karmada-io/karmada/pull/5714)
- add CRDs archive verification to enhance file system robustness (https://github.com/karmada-io/karmada/pull/5703 https://github.com/karmada-io/karmada/pull/5713)
- credit a Security Advisories (https://github.com/karmada-io/karmada/security/advisories/GHSA-7xg2-83f8-39mr)
- There are two draft Security Advisories pending release.




**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


