### PR TITLE
Proposing Karmada Adopter Group

### DIFF
--- a/adopter-group/README.md
+++ b/adopter-group/README.md
@@ -1,0 +1,150 @@
+# Karmada Adopter Group
+
+## Introduction
+
+The `Karmada Adopter Group` is a community effort to create a friendly and active space for people who use the Karmada
+project. This group helps users share knowledge, best practices, and experiences. It also gives users a chance to 
+connect with each other, work on projects together, and help improve Karmada.
+
+## Purpose
+
+The main goals of the Karmada Adopter Group are:
+
+- **Share Knowledge**: Help users share their experiences, challenges, and solutions related to using Karmada.
+- **Promote Collaboration**: Provide a place where users can work together, exchange ideas, and solve common problems.
+- **Support Users**: Offer resources, tutorials, and guidance to help users use Karmada.
+- **Gather Feedback**: Collect feedback from users to help guide the future development of Karmada.
+- **Increase Engagement**: Increase engagement within the Karmada community through regular meetups, webinars, and other events.
+
+## Membership
+
+### Who Can Join?
+
+The Karmada Adopter Group is open to **end users** and **vendors** who are currently using Karmada in production. 
+This includes:
+
+- **End Users**: Organizations that run Karmada in their production environments.
+- **Vendors**: Companies that offer products or services based on Karmada and have customers using it in production.
+
+**Note**: Right now, we do not require community contributions to join. However, in the future, we may ask members to 
+contribute to the Karmada community to maintain their membership.
+
+### How to Join
+
+To join the Karmada Adopter Group, follow these steps based on whether you are the first person from your company or an 
+additional member:
+
+#### For the First Developer from Your Company
+
+If you are the first developer from your company to join the Karmada Adopter Group, follow these simplified steps:
+
+1. **Leave a Comment on [this issue](https://github.com/karmada-io/karmada/issues/4540)**:
+   - Leave a comment on this issue with the required information.
+
+2. **Review and Onboarding**:
+   - Karmada maintainers will review your application to ensure you meet the criteria for membership.
+   - If everything looks good, the following onboarding steps will be initiated:
+      - **Update Adopter Group List**: Add your company to the list of [Karmada Adopter Group](https://karmada.io/adopters).
+      - **Send GitHub Invitation**: Send an invitation to add you to the `karmada-adopter-group` team on GitHub.
+      - **Mail Group Registration**: Add you to the `karmada-adopter-group@googlegroups.com` mail group.
+      - And so on.
+   - Once all onboarding steps are completed, your company will be officially listed as part of the Karmada Adopter Group,
+     and you will receive invitations to join the relevant teams and groups.
+
+#### For Additional Developers from an Existing Company
+
+If your company is already part of the Karmada Adopter Group and you are an additional developer who wants to join, follow
+these simplified steps:
+
+1. **Prepare Information**
+   - Your name
+   - Your company name: Be sure it already present on the [Karmada Adopter Group](https://karmada.io/adopters).
+   - Your email: The email address you want to use for joining the `karmada-adopter-group@googlegroups.com` mail group.
+   - Your GitHub ID: The GitHub ID for joining the `karmada-adopter-group` team on GitHub.
+
+2. **Send the Application**:
+   - Option 1: Open an [issue with the template](https://github.com/karmada-io/community/issues/new?assignees=RainbowMango&labels=area%2Fgithub-membership+%2Cadopter-group-membership&projects=&template=adopter-group-application.yaml&title=Karmada+Adopter+Group+Application+for+%5BYour+Name%5D), and fill in required information on the issue.
+   - Option 2: Email the maintainers(`cncf-karmada-maintainers@lists.cncf.io`) with the information on above.
+
+3. **Review and Addition**:
+   - Karmada maintainers will verify your request and initiate the following onboarding steps:
+      - **Send GitHub Invitation**: Send an invitation to add you to the `karmada-adopter-group` team on GitHub.
+      - **Mail Group Registration**: Add you to the `karmada-adopter-group@googlegroups.com` mail group.
+      - And so on.
+   - Once these steps are completed, you will receive invitations to join the relevant teams and groups.
+
+## Benefits of Joining
+
+By joining the Karmada Adopter Group, you will enjoy several benefits, including:
+
+- **Visibility for Your Company**: Your company's profile will be featured on the list of [Karmada Adopter Group](https://karmada.io/adopters), increasing visibility within the community.
+- **Networking Opportunities**: Connect with other Karmada users, developers, and enthusiasts from around the world.
+- **Exclusive Content**: Access to special content such as blog posts, case studies, and success stories shared by other members.
+- **Event Participation**: Invitations to participate in Karmada-related events, including KubeCon + CloudNativeCon, webinars, and meetups.
+- **Early Access to Features**: Get early access to new features, beta releases, bug fixes, and security updates.
+- **Job Postings**: Opportunity to post job openings related to Karmada on the [Karmada Community Supported Job Board(not available now)](TBD).
+- **Business Opportunities**: Potential business connections and collaborations with other members of the Karmada ecosystem.
+
+## GitHub Org Team
+
+The Karmada Adopter Group has a dedicated GitHub team specifically for verified members. This team is part of the 
+[karmada-io](https://github.com/karmada-io) organization and serves as a central hub for collaboration and communication
+among group members.
+
+- **Team Name**: `karmada-adopter-group`
+- **Permissions**: Members of this team have read-only access to the Karmada repositories and can participate in discussions and issues related to the Adopter Group.
+- **Invitation**: Once your application is approved, you will receive an invitation to join the team via GitHub.
+
+## Mail Group
+
+We maintain a dedicated Google Mail Group for the Karmada Adopter Group. This mail group is used for important 
+announcements, updates, and information sharing. Only verified members of the Karmada Adopter Group are added to this mail 
+group.
+
+- **Mail Group Address**: `karmada-adopter-group@googlegroups.com`
+- **Purpose**: This mail group is used to send out periodic updates, important announcements, and invitations to events.
+- **Subscription**: Once your application is approved, you will automatically be subscribed to the mail group.
+
+## Periodic Meetings
+
+Once we have enough members, we will discuss whether to hold regular meetings to facilitate more structured 
+communication and collaboration. These meetings could be held monthly, quarterly, or as needed, depending on the 
+preferences of the group members. The format and frequency of these meetings will be determined based on input from the 
+community.
+
+## Exit Mechanism
+
+Currently, there is no formal process for leaving the Karmada Adopter Group. However, the Karmada maintainer team reserves 
+the right to remove members if they violate community guidelines or fail to follow the principles of the group.
+
+## Usage of Adopter Group Information
+
+1. **Public Sharing**:
+  After joining the Karmada Adopter Group, the company name, company logo, and public use cases may be shared by the 
+  community in public forums (such as blogs, conferences, social media, etc.). 
+  However, **we will not publicly share any personal information**.
+
+2. **Prohibition of Commercial Use**:
+  All information related to the Karmada Adopter Group (including company names, logos, use cases, etc.) is intended for 
+  community engagement and promotion purposes only. 
+  **It is strictly prohibited for any company or individual to use this information for commercial purposes**. 
+  Without explicit authorization, no third party may use the Adopter Group information for any commercial activities.
+
+3. **Intellectual Property Protection**:
+  All content submitted to the Karmada Adopter Group (such as use cases, code snippets, documents, etc.) should comply with relevant laws, regulations, and open-source licensing agreements. If your submission includes third-party intellectual property, ensure that you have obtained the necessary authorization or permission.
+
+4. **Privacy Protection**:
+  We take your privacy seriously. All personal data (such as names, email addresses, GitHub IDs, etc.) will be used solely for internal communication and management purposes and will not be disclosed or shared with third parties unless you explicitly consent.
+
+5. **Adherence to Community Guidelines**:
+  As a member of the Karmada Adopter Group, you are expected to adhere to [the community's code of conduct](https://github.com/karmada-io/community/blob/main/CODE_OF_CONDUCT.md) and guidelines. Respect the rights and opinions of other members and actively participate in healthy discussions and collaborations.
+
+## Contact Information
+
+For any questions or assistance regarding the Karmada Adopter Group, please contact the following channels:
+
+- **Maintainer Mailing List**: [cncf-karmada-maintainers@lists.cncf.io](mailto:cncf-karmada-maintainers@lists.cncf.io)
+- **Maintainer Contacts**:
+   - Hongcai Ren (@RainbowMango) - [qdurenhongcai@gmail.com](mailto:qdurenhongcai@gmail.com)
+
+**Note**: This document is a work in progress and may be updated based on community feedback and evolving needs.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

In order to enhance communication and collaboration among users, and gather valuable feedback to guide the future development of the project, we propose to establish the `Karmada Adopter Group`(the Chinese name for this group is `用户组`).

As the Karmada project continues to grow, an increasing number of organizations are adopting Karmada in their production environments. To better support these users, we need a formal channel to:
- shares knowledge
- offer supports
- gather feedback
- and so on

Based on these goals and user feedback, we have decided to establish the Karmada Adopter Group and outline a detailed process for joining and the benefits for members.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Things need to be done along with this proposal:
- [ ] GitHub team, named `karmada-adopter-group`
- [x] Mail Group, named `karmada-adopter-group@googlegroups.com`
- [x] An issue template for the application of joining the group. (#100)
- [ ] Twist [current issue template](https://github.com/karmada-io/community/blob/main/.github/ISSUE_TEMPLATE/adopter-onboarding.md) for getting adopter on board as per the proposing process.


