### PR TITLE
Nominate Yanfeng as the member of security team

### DIFF
--- a/security-team/security-groups.md
+++ b/security-team/security-groups.md
@@ -30,3 +30,4 @@ Members:
 - Zefeng Wang([@Kevin Wang](https://github.com/kevin-wangzefeng)), [wangzefeng@huawei.com](mailto:wangzefeng@huawei.com)
 - Hongcai Ren([@RainbowMango](https://github.com/rainbowmango)), [renhongcai@huawei.com](mailto:renhongcai@huawei.com)
 - Zhuang Zhang([@zhzhuang-zju](https://github.com/zhzhuang-zju)), [guyue0864@gmail.com](mailto:guyue0864@gmail.com)
+- Yanfeng Huang([@yanfeng1992](https://github.com/yanfeng1992)), [huangyanfeng1992@gmail.com](mailto:huangyanfeng1992@gmail.com)


### PR DESCRIPTION
**What type of PR is this?**

/kind membership

**What this PR does / why we need it**:
This PR nominates @yanfeng1992, from [CECloud](https://cecloud.com/), for the Karmada Security Team. As a valued partner of the Karmada community, CECloud has demonstrated a strong commitment to enhancing capabilities and security.

CECloud places ​​security at the forefront​​ of their operations. This aligns with Karmada's ongoing efforts to strengthen its security posture, as evidenced by recent audits and proactive vulnerability management. For example, @yanfeng1992 actively contributed to identifying and addressing security risks in Karmada, such as the Security Advisory: https://github.com/karmada-io/karmada/security/advisories/GHSA-7xg2-83f8-39mr.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc current security team members for a vote.
cc @kevin-wangzefeng @zhzhuang-zju 

