### PR TITLE
Remove redundant spaces from approver/reviewer tables

### DIFF
--- a/APPROVERS.md
+++ b/APPROVERS.md
@@ -10,39 +10,39 @@ Please keep the below list sorted in ascending order.
 
 ## Approvers
 
-| Approver            | GitHub ID           | Affiliation             | Owners files                                                                                                                                  |
-|---------------------|---------------------|-------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
-| Amir Alavi          | @a7i                | Zendesk                 | karmada-io/karmada charts/                                                                                                                    |
-| Chaosi Pan          | @chaosi-zju         | ByteDance               | karmada-io/karmada karmadactl/                                                                                                                |
-| Chauncey            | @chaunceyjiang      | DaoCloud                | 1. karmada-io/karmada pkg/controllers<br>2. karmada-io/karmada pkg/metricsadapter/<br>3. karmada-io/karmada cmd/metrics-adapter/<br>...       |
-| Future              | @pidb               | AIML INSTITUTE          | karmada-io/karmada charts/                                                                                                                    |
-| Hanbo Li            | @mrlihanbo          | ByteDance               | karmada-io/karmada hack/                                                                                                                      |
-| Hongcai Ren         | @RainbowMango       | Huawei                  | 1. karmada-io/karmada<br>2. karmada-io/website                                                                                                |
-| Jinhui Ying         | @ikaven1024         | DiDi                    | 1. karmada-io/karmada hack/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada cmd/karmada-search/<br>...                          |
-| Joe Nathan Abellard | @jabellard          | Bloomberg               | karmada-io/karmada operators                                                                                                                  |
-| Junhua He           | @whitewindmills     | CECloud                 | karmada-io/karmada pkg/scheduler/                                                                                                             |
-| Kevin Wang          | @kevin-wangzefeng   | Huawei                  | 1. karmada-io/karmada<br>2. karmada-io/website                                                                                                |
-| Lei Xue             | @carmark            | Moore Threads           | karmada-io/community                                                                                                                          |
-| Michael Yao         | @windsonsea         | DaoCloud                | karmada-io/website i18n/                                                                                                                      |
-| Michas Szacillo     | @mszacillo          | Bloomberg               | karmada-io/karmada controllers, webhook                                                                                                       |
-| Prodan              | @prodanlabs         | Independent             | karmada-io/karmada pkg/karmadactl/cmdinit/                                                                                                    |
-| Qiangqiang Chang    | @charlesqq          | MoMo                    | karmada-io/karmada webhook/, controllers                                                                                                      |
-| Rui Fang            | @Garrybest          | Tencent                 | karmada-io/karmada                                                                                                                            |
-| Samzong Lu          | @SAMZONG            | DaoCloud                | karmada-io/website i18n/                                                                                                                      |
-| Shiyi Xie           | @GitHubxsy          | Huawei                  | karmada-io/community                                                                                                                          |
-| Tiecheng Shen       | @Poor12             | Huawei                  | 1. karmada-io/karmada charts/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/metricsadapter/<br>...                          |
-| Weicheng Lai        | @seanlaii           | Bloomberg               | karmada-io/karmada controllers, webhook                                                                                                       |
-| Wei Jiang           | @jwcesign           | CloudPilot AI, Inc      | 1. karmada-io/karmada pkg/metricsadapter/<br>2. karmada-io/karmada cmd/metrics-adapter/<br>3. karmada-io/karmada pkg/controllers/federatedhpa |
-| Wen Chen            | @calvin0327         | DaoCloud                | karmada-io/karmada operator/                                                                                                                  |
-| Wen Jiang           | @warjiang           | ByteDance               | karmada-io/dashboard                                                                                                                          |
-| Yan Li              | @huntsman-li        | Hualala                 | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/                                                                |
-| Yasong Li           | @liys87x            | Hualala                 | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/                                                                |
-| Yifan Shen          | @zoroyouxi          | ICBC                    | karmada-io/community                                                                                                                          |
-| Yiheng Ci           | @lfbear             | Tiger Brokers           | karmada-io/karmada hack/                                                                                                                      |
-| Yike Bu             | @yike21             | UESTC                   | karmada-io/karmada pkg/resourceinterpreter/default/thirdparty/                                                                                |
-| Yingjun Wu          | @wuyingjun-lucky    | China Mobile Cloud      | karmada-io/karmada pkg/karmadactl/addons/                                                                                                     |
-| Yuanpeng Liang      | @liangyuanpeng      | Yunhorn                 | karmada-io/karmada hack/, .github                                                                                                             |
-| Zhe Cheng           | @lonelyCZ           | SEL-Zhejiang University | 1. karmada-io/karmada cmd/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/karmadactl/                                        |
-| Zhen Chang          | @XiShanYongYe-Chang | Huawei                  | 1. karmada-io/karmada test/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada pkg/registry/<br>...                                |
-| Zhuang Zhang        | @zhzhuang-zju       | Huawei                  | 1. karmada-io/karmada operator/                                                                                                               |
-| Zongqing Li         | @zach593            | Trip.com                | karmada-io/karmada controllers                                                                                                                |
+| Approver | GitHub ID | Affiliation | Owners files |
+|----------|-----------|-------------|--------------|
+| Amir Alavi | @a7i | Zendesk | karmada-io/karmada charts/ |
+| Chaosi Pan | @chaosi-zju | ByteDance | karmada-io/karmada karmadactl/ |
+| Chauncey | @chaunceyjiang | DaoCloud | 1. karmada-io/karmada pkg/controllers<br>2. karmada-io/karmada pkg/metricsadapter/<br>3. karmada-io/karmada cmd/metrics-adapter/<br>... |
+| Future | @pidb | AIML INSTITUTE | karmada-io/karmada charts/ |
+| Hanbo Li | @mrlihanbo | ByteDance | karmada-io/karmada hack/ |
+| Hongcai Ren | @RainbowMango | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
+| Jinhui Ying | @ikaven1024 | DiDi | 1. karmada-io/karmada hack/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada cmd/karmada-search/<br>... |
+| Joe Nathan Abellard | @jabellard | Bloomberg | karmada-io/karmada operators |
+| Junhua He | @whitewindmills | CECloud | karmada-io/karmada pkg/scheduler/ |
+| Kevin Wang | @kevin-wangzefeng | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
+| Lei Xue | @carmark | Moore Threads | karmada-io/community |
+| Michael Yao | @windsonsea | DaoCloud | karmada-io/website i18n/ |
+| Michas Szacillo | @mszacillo | Bloomberg | karmada-io/karmada controllers, webhook |
+| Prodan | @prodanlabs | Independent | karmada-io/karmada pkg/karmadactl/cmdinit/ |
+| Qiangqiang Chang | @charlesqq | MoMo | karmada-io/karmada webhook/, controllers |
+| Rui Fang | @Garrybest | Tencent | karmada-io/karmada |
+| Samzong Lu | @SAMZONG | DaoCloud | karmada-io/website i18n/ |
+| Shiyi Xie | @GitHubxsy | Huawei | karmada-io/community |
+| Tiecheng Shen | @Poor12 | Huawei | 1. karmada-io/karmada charts/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/metricsadapter/<br>... |
+| Weicheng Lai | @seanlaii | Bloomberg | karmada-io/karmada controllers, webhook |
+| Wei Jiang | @jwcesign | CloudPilot AI, Inc | 1. karmada-io/karmada pkg/metricsadapter/<br>2. karmada-io/karmada cmd/metrics-adapter/<br>3. karmada-io/karmada pkg/controllers/federatedhpa |
+| Wen Chen | @calvin0327 | DaoCloud | karmada-io/karmada operator/ |
+| Wen Jiang | @warjiang | ByteDance | karmada-io/dashboard |
+| Yan Li | @huntsman-li | Hualala | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/ |
+| Yasong Li | @liys87x | Hualala | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/ |
+| Yifan Shen | @zoroyouxi | ICBC | karmada-io/community |
+| Yiheng Ci | @lfbear | Tiger Brokers | karmada-io/karmada hack/ |
+| Yike Bu | @yike21 | UESTC | karmada-io/karmada pkg/resourceinterpreter/default/thirdparty/ |
+| Yingjun Wu | @wuyingjun-lucky | China Mobile Cloud | karmada-io/karmada pkg/karmadactl/addons/ |
+| Yuanpeng Liang | @liangyuanpeng | Yunhorn | karmada-io/karmada hack/, .github |
+| Zhe Cheng | @lonelyCZ | SEL-Zhejiang University | 1. karmada-io/karmada cmd/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/karmadactl/ |
+| Zhen Chang | @XiShanYongYe-Chang | Huawei | 1. karmada-io/karmada test/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada pkg/registry/<br>... |
+| Zhuang Zhang | @zhzhuang-zju | Huawei | 1. karmada-io/karmada operator/ |
+| Zongqing Li | @zach593 | Trip.com | karmada-io/karmada controllers |

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -10,51 +10,51 @@ Please keep the below list sorted in ascending order.
 
 ## Reviewers
 
-| Reviewers           | GitHub ID           | Affiliation             | Owners files                                                                                                                                   |
-|---------------------|---------------------|-------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| Amir Alavi          | @a7i                | Zendesk                 | karmada-io/karmada charts/                                                                                                                     |
-| Baofa Fan           | @carlory            | DaoCloud                | karmada-io/karmada pkg/karmadactl                                                                                                              |
-| Chaosi Pan          | @chaosi-zju         | ByteDance               | karmada-io/karmada karmadactl/                                                                                                                 |
-| Chauncey            | @chaunceyjiang      | DaoCloud                | 1. karmada-io/karmada pkg/controllers<br>2. karmada-io/karmada pkg/metricsadapter/<br>3. karmada-io/karmada cmd/metrics-adapter/<br>...        |
-| Future              | @pidb               | AIML INSTITUTE          | karmada-io/karmada charts/                                                                                                                     |
-| Hanbo Li            | @mrlihanbo          | ByteDance               | karmada-io/karmada hack/                                                                                                                       |
-| Hongcai Ren         | @RainbowMango       | Huawei                  | 1. karmada-io/karmada<br>2. karmada-io/website                                                                                                 |
-| Hui Jiang           | @jhnine             | Joint Cloud             | karmada-io/dashboard                                                                                                                           |
-| Ihor Sychevskyi     | @Arhell             | Phalcon                 | karmada-io/website                                                                                                                             |
-| Jie Zhang           | @devadapter         | Joint Cloud             | karmada-io/dashboard                                                                                                                           |
-| Jinhui Ying         | @ikaven1024         | DiDi                    | 1. karmada-io/karmada hack/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada cmd/karmada-search/<br>...                           |
-| Joe Nathan Abellard | @jabellard          | Bloomberg               | karmada-io/karmada operators                                                                                                                   |
-| Junhua He           | @whitewindmills     | CECloud                 | karmada-io/karmada pkg/scheduler/                                                                                                              |
-| Jun Qian            | @qianjun1993        | Tencent                 | karmada-io/karmada pkg/scheduler/                                                                                                              |
-| Kevin Wang          | @kevin-wangzefeng   | Huawei                  | 1. karmada-io/karmada<br>2. karmada-io/website                                                                                                 |
-| Lei Xue             | @carmark            | Moore Threads           | karmada-io/community                                                                                                                           |
-| Michael Yao         | @windsonsea         | DaoCloud                | karmada-io/website i18n/                                                                                                                       |
-| Michas Szacillo     | @mszacillo          | Bloomberg               | karmada-io/karmada controllers, webhook                                                                                                        |
-| Prodan              | @prodanlabs         | Independent             | karmada-io/karmada pkg/karmadactl/cmdinit/                                                                                                     |
-| Qiangqiang Chang    | @charlesqq          | MoMo                    | karmada-io/karmada webhook/, controllers                                                                                                       |
-| Rentian Zhou        | @Vacant2333         | Independent             | karmada-io/karmada test/                                                                                                                       |
-| Rui Fang            | @Garrybest          | Tencent                 | karmada-io/karmada                                                                                                                             |
-| Rui Jiang           | @jrkeen             | BMW-CIH                 | karmada-io/karmada charts/                                                                                                                     |
-| Rupesh Gelal        | @rgrupesh           | Independent             | karmada-io/website                                                                                                                             |
-| Samzong Lu          | @SAMZONG            | DaoCloud                | karmada-io/website                                                                                                                             |
-| Shiyi Xie           | @GitHubxsy          | Huawei                  | karmada-io/community                                                                                                                           |
-| Tao Ling            | @Tingtal            | Huawei                  | 1. karmada-io/karmada docs/<br>2. karmada-io/website docs/                                                                                     |
-| Tiecheng Shen       | @Poor12             | Huawei                  | 1. karmada-io/karmada charts/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/metricsadapter/<br>...                           |
-| Wang Bing           | @pigletfly          | Youzan                  | karmada-io/website                                                                                                                             |
-| Wei Jiang           | @jwcesign           | CloudPilot AI, Inc      | 1. karmada-io/karmada pkg/metricsadapter/<br>2. karmada-io/karmada cmd/metrics-adapter/<br>3. karmada-io/karmada pkg/controllers/federatedhpa/ |
-| Weicheng Lai        | @seanlaii           | Bloomberg               | karmada-io/karmada controllers, webhook                                                                                                        |
-| Wen Chen            | @calvin0327         | DaoCloud                | karmada-io/karmada operator/                                                                                                                   |
-| Wen Jiang           | @warjiang           | ByteDance               | karmada-io/dashboard                                                                                                                           |
-| Xinzhao Xu          | @iawia002           | Kubesphere              | karmada-io/karmada pkg/resourceinterpreter/                                                                                                    |
-| Yangfeng Huang      | @yanfeng1992        | CECloud                 | karmada-io/karmada pkg/karmadactl                                                                                                              |
-| Yan Li              | @huntsman-li        | Hualala                 | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/                                                                 |
-| Yasong Li           | @liys87x            | Hualala                 | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/                                                                 |
-| Yifan Shen          | @zoroyouxi          | ICBC                    | karmada-io/community                                                                                                                           |
-| Yiheng Ci           | @lfbear             | Tiger Brokers           | karmada-io/karmada hack/                                                                                                                       |
-| Yike Bu             | @yike21             | UESTC                   | karmada-io/karmada pkg/resourceinterpreter/default/thirdparty/                                                                                 |
-| Yingjun Wu          | @wuyingjun-lucky    | China Mobile Cloud      | karmada-io/karmada pkg/karmadactl/addons/                                                                                                      |
-| Yuanpeng Liang      | @liangyuanpeng      | Yunhorn                 | karmada-io/karmada hack/                                                                                                                       |
-| Zhe Cheng           | @lonelyCZ           | SEL-Zhejiang University | 1. karmada-io/karmada cmd/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/karmadactl/                                         |
-| Zhen Chang          | @XiShanYongYe-Chang | Huawei                  | 1. karmada-io/karmada test/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada pkg/registry/<br>...                                 |
-| Zhuang Zhang        | @zhzhuang-zju       | Huawei                  | 1. karmada-io/karmada operator/                                                                                                                |
-| Zongqing Li         | @zach593            | Trip.com                | karmada-io/karmada controllers                                                                                                                 |
+| Reviewers | GitHub ID | Affiliation | Owners files |
+|-----------|-----------|-------------|--------------|
+| Amir Alavi | @a7i | Zendesk | karmada-io/karmada charts/ |
+| Baofa Fan | @carlory | DaoCloud | karmada-io/karmada pkg/karmadactl |
+| Chaosi Pan | @chaosi-zju | ByteDance | karmada-io/karmada karmadactl/ |
+| Chauncey | @chaunceyjiang | DaoCloud | 1. karmada-io/karmada pkg/controllers<br>2. karmada-io/karmada pkg/metricsadapter/<br>3. karmada-io/karmada cmd/metrics-adapter/<br>... |
+| Future | @pidb | AIML INSTITUTE | karmada-io/karmada charts/ |
+| Hanbo Li | @mrlihanbo | ByteDance | karmada-io/karmada hack/ |
+| Hongcai Ren | @RainbowMango | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
+| Hui Jiang | @jhnine | Joint Cloud | karmada-io/dashboard |
+| Ihor Sychevskyi | @Arhell | Phalcon | karmada-io/website |
+| Jie Zhang | @devadapter | Joint Cloud | karmada-io/dashboard |
+| Jinhui Ying | @ikaven1024 | DiDi | 1. karmada-io/karmada hack/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada cmd/karmada-search/<br>... |
+| Joe Nathan Abellard | @jabellard | Bloomberg | karmada-io/karmada operators |
+| Junhua He | @whitewindmills | CECloud | karmada-io/karmada pkg/scheduler/ |
+| Jun Qian | @qianjun1993 | Tencent | karmada-io/karmada pkg/scheduler/ |
+| Kevin Wang | @kevin-wangzefeng | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
+| Lei Xue | @carmark | Moore Threads | karmada-io/community |
+| Michael Yao | @windsonsea | DaoCloud | karmada-io/website i18n/ |
+| Michas Szacillo | @mszacillo | Bloomberg | karmada-io/karmada controllers, webhook |
+| Prodan | @prodanlabs | Independent | karmada-io/karmada pkg/karmadactl/cmdinit/ |
+| Qiangqiang Chang | @charlesqq | MoMo | karmada-io/karmada webhook/, controllers |
+| Rentian Zhou | @Vacant2333 | Independent | karmada-io/karmada test/ |
+| Rui Fang | @Garrybest | Tencent | karmada-io/karmada |
+| Rui Jiang | @jrkeen | BMW-CIH | karmada-io/karmada charts/ |
+| Rupesh Gelal | @rgrupesh | Independent | karmada-io/website |
+| Samzong Lu | @SAMZONG | DaoCloud | karmada-io/website |
+| Shiyi Xie | @GitHubxsy | Huawei | karmada-io/community |
+| Tao Ling | @Tingtal | Huawei | 1. karmada-io/karmada docs/<br>2. karmada-io/website docs/ |
+| Tiecheng Shen | @Poor12 | Huawei | 1. karmada-io/karmada charts/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/metricsadapter/<br>... |
+| Wang Bing | @pigletfly | Youzan | karmada-io/website |
+| Wei Jiang | @jwcesign | CloudPilot AI, Inc | 1. karmada-io/karmada pkg/metricsadapter/<br>2. karmada-io/karmada cmd/metrics-adapter/<br>3. karmada-io/karmada pkg/controllers/federatedhpa/ |
+| Weicheng Lai | @seanlaii | Bloomberg | karmada-io/karmada controllers, webhook |
+| Wen Chen | @calvin0327 | DaoCloud | karmada-io/karmada operator/ |
+| Wen Jiang | @warjiang | ByteDance | karmada-io/dashboard |
+| Xinzhao Xu | @iawia002 | Kubesphere | karmada-io/karmada pkg/resourceinterpreter/ |
+| Yangfeng Huang | @yanfeng1992 | CECloud | karmada-io/karmada pkg/karmadactl |
+| Yan Li | @huntsman-li | Hualala | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/ |
+| Yasong Li | @liys87x | Hualala | 1. karmada-io/karmada pkg/search/<br>2. karmada-io/karmada cmd/karmada-search/ |
+| Yifan Shen | @zoroyouxi | ICBC | karmada-io/community |
+| Yiheng Ci | @lfbear | Tiger Brokers | karmada-io/karmada hack/ |
+| Yike Bu | @yike21 | UESTC | karmada-io/karmada pkg/resourceinterpreter/default/thirdparty/ |
+| Yingjun Wu | @wuyingjun-lucky | China Mobile Cloud | karmada-io/karmada pkg/karmadactl/addons/ |
+| Yuanpeng Liang | @liangyuanpeng | Yunhorn | karmada-io/karmada hack/ |
+| Zhe Cheng | @lonelyCZ | SEL-Zhejiang University | 1. karmada-io/karmada cmd/<br>2. karmada-io/karmada operator/<br>3. karmada-io/karmada pkg/karmadactl/ |
+| Zhen Chang | @XiShanYongYe-Chang | Huawei | 1. karmada-io/karmada test/<br>2. karmada-io/karmada pkg/search/<br>3. karmada-io/karmada pkg/registry/<br>... |
+| Zhuang Zhang | @zhzhuang-zju | Huawei | 1. karmada-io/karmada operator/ |
+| Zongqing Li | @zach593 | Trip.com | karmada-io/karmada controllers |


### PR DESCRIPTION
As discussed in https://github.com/karmada-io/community/pull/141#issuecomment-3072526332
Only removed redundant spaces from two big tables, to easily track the diff changes in future.

/kind cleanup
/kind documentation