### PR TITLE
Update devstats link which previously link to k8s's

### DIFF
--- a/.github/ISSUE_TEMPLATE/adopter-group-application.yaml
+++ b/.github/ISSUE_TEMPLATE/adopter-group-application.yaml
@@ -62,7 +62,7 @@ body:
           required: true
         - label: I have subscribed to the [Karmada mailing list](https://groups.google.com/forum/#!forum/karmada)
           required: true
-        - label: "Ensure your [affiliation in gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#addingupdating-affiliation) is up to date (gitdm is used by [devstats](https://k8s.devstats.cncf.io/) to track affiliation)"
+        - label: "Ensure your [affiliation in gitdm](https://github.com/cncf/gitdm?tab=readme-ov-file#addingupdating-affiliation) is up to date (gitdm is used by [devstats](https://karmada.devstats.cncf.io/) to track affiliation)"
           required: true
         - label: "Ensure your [affiliation in openprofile.dev](https://openprofile.dev/edit/profile) is up to date (used by [LFX Insights](https://insights.lfx.dev/) to track affiliation, will replace gitdm in the future)"
           required: true


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This pull request updates the devstats link in the adopter group application template. The previous link pointed to the Kubernetes devstats page, and this change corrects it to point to the Karmada-specific devstats page. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


