### PR TITLE
Add Karmada org members benefits

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -59,6 +59,7 @@ Members are expected to remain active contributors to the community.
 - Members can do `/lgtm` on open PRs.
 - They can be assigned to issues and PRs, and people can ask members for reviews with a `/cc @username`.
 - Members can do `/close` to close PRs as well.
+- Members are eligible to attend the CNCF Maintainer Summit (exclusive event during KubeCon).
 
 **Note:** members who frequently contribute code are expected to proactively
 perform code reviews and work towards becoming a primary *reviewer* for the


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Add one more benefit for Karmada org members. 
Just noticed Karmada org members are eligible to attend the CNCF Maintainer Summit.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/features-add-ons/maintainer-summit/#about.

