### PR TITLE
Nominate Wenjiang Ding as the member of security team

### DIFF
--- a/security-team/security-groups.md
+++ b/security-team/security-groups.md
@@ -32,3 +32,4 @@ Members:
 - Hongcai Ren([@RainbowMango](https://github.com/rainbowmango)), [renhongcai@huawei.com](mailto:renhongcai@huawei.com)
 - Zhuang Zhang([@zhzhuang-zju](https://github.com/zhzhuang-zju)), [guyue0864@gmail.com](mailto:guyue0864@gmail.com)
 - Yanfeng Huang([@yanfeng1992](https://github.com/yanfeng1992)), [huangyanfeng1992@gmail.com](mailto:huangyanfeng1992@gmail.com)
+- Wenjiang Ding([@warjiang](https://github.com/warjiang)), [1096409085@qq.com](mailto:1096409085@qq.com)


### PR DESCRIPTION
**What type of PR is this?**

/kind membership

**What this PR does / why we need it**:
This PR nominates @warjiang as a member of the Karmada Security Team.

As the primary maintainer of the Karmada Dashboard, he has made significant and consistent contributions to the project, including driving and delivering two major releases. Their deep understanding of the codebase and commitment to code quality have greatly improved the stability and usability of the dashboard.

Notably, they actively participated in handling a recent security disclosure, [Karmada Dashboard API Unauthorized Access Vulnerability](https://github.com/karmada-io/dashboard/security/advisories/GHSA-5qjg-9mjh-4r92), demonstrating strong responsibility, technical proficiency, and adherence to security best practices throughout the process. Their responsiveness and collaboration during the sensitive resolution period were instrumental in ensuring a timely and coordinated fix.

Given their proven track record, ownership mindset, and demonstrated capability in managing security-sensitive issues, I believe they will be a valuable addition to the Security Team and help strengthen Karmada’s overall security posture.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc current security team members for a vote.
cc @kevin-wangzefeng @zhzhuang-zju @yanfeng1992 

