### PR TITLE
Setup Karmada github organization management

### DIFF
--- a/github-config/OWNERS
+++ b/github-config/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- RainbowMango
+approvers:
+- RainbowMango
+options:
+  no_parent_owners: true

--- a/github-config/README.md
+++ b/github-config/README.md
@@ -1,0 +1,56 @@
+# GitHub Organization Management
+
+This directory contains the configuration for managing the Karmada GitHub organization, including team memberships, repository settings, and access controls.
+
+## Purpose
+
+The configurations in this directory serve to:
+
+- Transparency: All team memberships and repository permissions are publicly visible and tracked in version control
+- Automation: Changes are automatically applied through pull requests and reviews
+- Accountability: Every permission change has a clear history and approval process
+
+## Structure
+
+- `config.yaml` - Complete configuration for teams, members, and repository permissions
+
+## Making Changes
+
+To modify team memberships or repository permissions:
+
+1. Create a pull request with your proposed changes
+2. Get approval from appropriate maintainers/approvers
+3. Changes will be automatically applied after merge
+
+## Automation
+
+This directory uses [CNCF CLOWarden](https://github.com/cncf/clowarden) to automate the management of teams, members, and repository permissions.
+
+### How It Works
+
+- **Pull Request Validation**: When a PR is submitted, CLOWarden validates the configuration file for correctness and compliance
+- **Automatic Application**: After the PR is merged, CLOWarden automatically applies the changes to the GitHub organization
+- **Periodic Reconciliation**: CLOWarden periodically reconciles the actual state with the desired state to ensure consistency
+
+### What Gets Managed
+
+- **Teams**: Fully managed by CLOWarden
+  - Teams not defined in the configuration will be removed during reconciliation
+  - Team maintainers and members not defined in the configuration will be removed from teams
+
+- **Team Members**: Managed at the team level
+  - Team membership (both maintainers and members) is defined per team
+  - Team members not defined in the configuration will be removed from their teams during reconciliation
+
+- **Organization Members**: Not managed by CLOWarden
+  - Organization-level members (those not assigned to any team) are completely outside CLOWarden's scope
+  - These members will not be affected by any reconciliation process
+  - Organization membership must be managed separately through GitHub settings
+
+- **Repositories**: Completely protected from deletion
+  - CLOWarden **does NOT support repository deletion operations**
+  - Repositories can only be added via configuration, never removed
+  - This is a deliberate safety design to prevent accidental data loss
+  - Even if a repository is removed from the configuration, the actual GitHub repository will remain untouched
+
+For more information about CLOWarden, visit the [official repository](https://github.com/cncf/clowarden).

--- a/github-config/config.yaml
+++ b/github-config/config.yaml
@@ -1,0 +1,76 @@
+teams:
+- name: karmada-adopter-group
+  maintainers:
+  - RainbowMango
+  - kevin-wangzefeng
+  members:
+  - CharlesQQ
+  - dongjiang1989
+  - guozheng-shen
+  - ivan-cai
+  - LivingCcj
+  - NickYadance
+  - stulzq
+  - vie-serendipity
+  - yangsoon
+  - zach593
+- name: repo-admins
+  maintainers:
+  - RainbowMango
+  - kevin-wangzefeng
+  members: []
+repositories:
+- name: api
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: community
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: dashboard
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: karmada
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: kubernetes
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: multi-cluster-ingress-nginx
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: multicluster-cloud-provider
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: playground
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public
+- name: website
+  collaborators:
+    karmada-bot: admin
+  teams:
+    repo-admins: admin
+  visibility: public


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR sets up the policy of GitHub organization management.

**Which issue(s) this PR fixes**:
Part of #164

**Special notes for your reviewer**:
We haven't enabled the CLOWarden Service yet, will double-check the configuration (config.yaml) before enabling the service, to make sure the actual state is in sync. 
