### PR TITLE
add security-team in config.yaml

### DIFF
--- a/github-config/config.yaml
+++ b/github-config/config.yaml
@@ -24,6 +24,14 @@ teams:
   - RainbowMango
   members:
   - karmada-bot
+- name: karmada-security-team
+  maintainers:
+  - kevin-wangzefeng
+  - RainbowMango
+  members:
+  - warjiang
+  - yanfeng1992
+  - zhzhuang-zju
 repositories:
 - name: api
   teams:

--- a/security-team/SECURITY.md
+++ b/security-team/SECURITY.md
@@ -6,12 +6,7 @@ We sincerely request you to keep the vulnerability information confidential and 
 
 To report a vulnerability, please contact the Security Team: [cncf-karmada-security@lists.cncf.io](mailto:cncf-karmada-security@lists.cncf.io). You can email the Security Team with the security details and the details expected for [Karmada bug reports](https://github.com/karmada-io/karmada/blob/master/.github/ISSUE_TEMPLATE/bug-report.md). 
 
-The information of the Security Team members is described as follows:
-
-| Name                                                                  | Email                 |
-|-----------------------------------------------------------------------|-----------------------|
-| Kevin Wang ([@kevin-wangzefeng](https://github.com/kevin-wangzefeng)) | wangzefeng@huawei.com |
-| Hongcai Ren ([@RainbowMango](https://github.com/RainbowMango))        | renhongcai@huawei.com |
+The information of the Security Team members can be found [here](security-groups.md#the-security-team).
 
 ### E-mail Response
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation
<!--
Add one of the following kinds:

/kind cleanup
/kind deprecation
/kind documentation
/kind failing-test
/kind flake

-->

**What this PR does / why we need it**:
Currently, the community manages GitHub teams through Clowarden. Since the Security Team is already operating maturely, I hope to use Clowarden to manage the Security Team uniformly as a GitHub team.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


