### PR TITLE
Clarify maintainer seat governance in GOVERNANCE

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -40,10 +40,23 @@ The Karmada and its leadership embrace the following values:
 The [Community Membership](https://github.com/karmada-io/community/blob/main/community-membership.md)
 outlines responsibilities and requirements for different roles in Karmada.
 
-Currently, the maintainers are the governing body for the project. To maintain 
-openness and vendor neutrality, `no single vendor or organization may hold more 
-than 50% of maintainer seats`. This may change as the community grows, such as by 
-adopting an elected steering committee.
+Currently, the maintainers are the governing body for the project. To maintain
+openness and vendor neutrality, `no single vendor or organization may hold more
+than 50% of maintainer seats`.
+
+New maintainers are selected through a nomination and voting mechanism. Current
+maintainers nominate candidates who have demonstrated deep technical understanding
+and sustained contributions.
+
+There is no predefined limit on the number of maintainer seats. The community may
+grow the number of maintainers as needed based on project growth and contribution
+levels.
+
+Maintainers serve indefinitely and may remain in the role as long as they remain
+active and engaged with the project. Maintainers may step down voluntarily or may
+be transitioned to emeritus status based on inactivity and community balance
+considerations. See [community-membership.md](https://github.com/karmada-io/community/blob/main/community-membership.md)
+for detailed maintainer requirements and processes.
 
 ## Meetings
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR clarifies the governance structure for maintainer seats by documenting:

- **Selection mechanism**: Nomination and super-majority (2/3) voting by current maintainers
- **Seat limit**: No predefined limit; grows based on project needs and contribution levels
- **Term limit**: Indefinite terms with voluntary or activity-based transitions to emeritus status

This addresses ambiguity around how maintainer seats are managed and provides transparency for the community.

Ref: [community-membership.md](https://github.com/karmada-io/community/blob/main/community-membership.md)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR does not intend make any changes to the governance, but clarify the rules to address any potential ambiguity. 

