### PR TITLE
Add new adopter members

### DIFF
--- a/github-config/config.yaml
+++ b/github-config/config.yaml
@@ -6,18 +6,20 @@ teams:
   members:
   - Allen-987 # SenseTime
   - baizhushui # SenseTime
-  - CharlesQQ
-  - dongjiang1989
-  - guozheng-shen
-  - ivan-cai
+  - CharlesQQ # HelloGroup
+  - dongjiang1989 # iFLYTEK
+  - gjbravi # Wellhub
+  - guozheng-shen # Tongcheng Travel
+  - ivan-cai # Alibaba Cloud
   - kechujian-creator # Songke
-  - LivingCcj
+  - LivingCcj # Bilibili
   - liwang0513 # Bloomberg
-  - NickYadance
-  - stulzq
-  - vie-serendipity
-  - yangsoon
-  - zach593
+  - NickYadance # Shopee
+  - stulzq # Tongcheng Travel
+  - vie-serendipity # Alibaba Cloud
+  - xiaokangwang1992 # GMI Cloud
+  - yangsoon # RedNote
+  - zach593 # Trip.com Group
   - ZhengXinwei-F # SenseTime
 - name: karmada-maintainers
   maintainers:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pull request updates the `teams` section in `github-config/config.yaml` by adding company affiliations as comments next to each team member. This provides clearer context on each member's organizational association.

Team member affiliation updates:

* Added company affiliations as comments for existing team members, such as `CharlesQQ # HelloGroup`, `dongjiang1989 # iFLYTEK`, and others, to clarify their organizational associations.
* Added new members with company affiliations, including `xiaokangwang1992 # GMI Cloud` and `gjbravi # Wellhub`.

**Which issue(s) this PR fixes**:
Part of #195, #192

**Special notes for your reviewer**:


