### PR TITLE
Add sigs definition and introduction

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -146,7 +146,9 @@ Any Maintainer may demand a vote be taken.
 1. **Updating the project roadmap**
 2. **Growing new maintainers**
 3. **Accepting new subproject**
-4. **Updating the project governance charter**
+4. **Creating a new [SIG](sigs/README.md)**
+5. **Retiring a [SIG](sigs/README.md)**
+6. **Updating the project governance charter**
 
 ## Modifying this Charter
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Resources:
 - [Meeting Calendar](https://calendar.google.com/calendar/embed?src=karmadaoss%40gmail.com&ctz=Asia%2FShanghai) | [Subscribe](https://calendar.google.com/calendar/u/1?cid=a2FybWFkYW9zc0BnbWFpbC5jb20)
 - [Meeting Link](https://zoom.com/my/karmada)
 
+## SIG Meetings
+
+[Special Interest Groups (SIGs)](sigs/README.md) hold their own meetings to discuss topics within their scope. For the
+latest meeting information, including schedule, agenda, notes, and other details, please refer to each SIG page:
+
+- [SIG-UI](sigs/sig-ui/README.md)
+- [SIG-Scalability](sigs/sig-scalability/README.md)
+
 ## Contact
 
 If you have questions, feel free to reach out to us in the following ways:

--- a/sigs/README.md
+++ b/sigs/README.md
@@ -1,0 +1,101 @@
+# Special Interest Groups
+
+Special Interest Groups (SIGs) are lightweight, topic-oriented groups formed to
+coordinate design reviews, technical discussions, and community collaboration in
+specific areas of Karmada. SIGs are open to all community members and operate in
+public.
+
+SIGs in Karmada are intentionally lightweight and are coordinated by one or more
+leads. They do not require a separate charter document. Each SIG should keep its
+scope, discussions, agenda, and notes accessible to the community.
+
+The current list of SIGs is maintained as:
+
+- [SIG-UI](sig-ui/README.md)
+- [SIG-Scalability](sig-scalability/README.md)
+
+## Scope
+
+A SIG focuses on a specific technical area or user experience topic in the
+Karmada ecosystem. Within its defined scope, a SIG may:
+
+- Host design reviews and technical discussions.
+- Collect feedback from users and contributors.
+- Document ongoing work, open questions, and meeting notes in public.
+- Make decisions that are binding within the SIG's scope.
+
+If a SIG cannot reach consensus on a topic, the matter should be escalated to
+the [Community Meeting](../README.md#community-meeting) for resolution.
+
+For topics that span multiple SIGs, the leads of the relevant SIGs should collaborate
+to resolve the issue. If they cannot reach agreement, the matter should be escalated
+to the Community Meeting.
+
+## Leads
+
+Each SIG should have one or more leads. Having multiple leads is recommended to
+share the workload and ensure continuity.
+
+### Responsibilities
+
+- Organize and facilitate SIG meetings.
+- Maintain the meeting agenda and ensure meeting notes are recorded.
+- Drive discussions and follow up on action items.
+- Coordinate with other SIGs or escalate topics to the [Community Meeting](../README.md#community-meeting)
+  when needed.
+
+### Requirements
+
+Leads must be [members](../community-membership.md) of the Karmada community.
+
+### Selection and Changes
+
+- Initial leads are proposed as part of the SIG creation process.
+- New leads may be added through agreement among the existing leads.
+- Leads may step down voluntarily at any time by informing the other leads (or
+  Maintainers if no other leads exist).
+- If a lead becomes inactive for more than six months, the remaining leads (or
+  Maintainers if no other leads exist) may propose a replacement through the
+  SIG's regular discussion channels.
+
+## Participation
+
+Participation in any SIG is fully open. Anyone may join SIG meetings, contribute
+to discussions, add items to the meeting agenda, and participate in design
+reviews. No approval or membership prerequisite is required.
+
+## Meetings
+
+SIGs typically hold biweekly meetings. Meetings may be canceled or rescheduled
+when there are no agenda items or during major events such as KubeCon. Meeting
+notes, agendas, and participant information are maintained in each SIG's public
+meeting document.
+
+## Creating a SIG
+
+Creating a new SIG requires a two-thirds majority vote of all Maintainers, as
+described in the [Governance Voting](../GOVERNANCE.md#voting) section.
+
+A proposal to create a SIG should be submitted as an issue in the
+[karmada-io/community](https://github.com/karmada-io/community) repository. The
+proposal should include:
+
+- The proposed SIG name.
+- A clear description of the scope and purpose.
+- The initial leads.
+- The initial communication channels (e.g., Slack channel, mailing list).
+- A public meeting notes document.
+
+## Retiring a SIG
+
+A SIG may be retired when its goals have been completed, its scope is no longer
+relevant, or it has become inactive. Retiring a SIG requires a two-thirds
+majority vote of all Maintainers, as described in the [Governance Voting](../GOVERNANCE.md#voting)
+section.
+
+A proposal to retire a SIG should be submitted as an issue in the
+[karmada-io/community](https://github.com/karmada-io/community) repository. The
+proposal should notify the SIG's leads and all maintainers, and be announced on
+public community channels (e.g., Slack, mailing list).
+
+Once approved, a pull request should update the target SIG document.

--- a/sigs/sig-scalability/README.md
+++ b/sigs/sig-scalability/README.md
@@ -1,0 +1,34 @@
+# SIG-Scalability
+
+## Overview
+
+Karmada scalability-related design reviews and technical discussions.
+
+## Scope
+
+This SIG focuses on identifying and addressing performance bottlenecks,
+optimizing resource usage, and improving the overall scalability of Karmada. It
+is open to all Karmada community members. If there is anything you want to
+discuss, please add an item to the meeting agenda.
+
+## Meetings
+
+Regular Community Meeting:
+* Friday at 16:00 UTC+8 (Chinese)(biweekly). [Convert to your timezone](https://dateful.com/convert/utc8?t=1600).
+
+Resources:
+- [Meeting Notes and Agenda](https://docs.google.com/document/d/1BUZBDvtbtfU9MmOz7KVdvGiiCny-zz_34FuLlW4AGmM/edit?tab=t.0)
+- [Meeting Calendar](https://calendar.google.com/calendar/u/0?cid=ZDVhMWNiMzViZjcwNDU2MWRkZTNkMzQ0NjVlNzU3Y2Y4ZWIzMmFmODc5ZmEwNTUzZjczZjJlYzA1ZmE0MzM5Y0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) | [Subscribe](https://calendar.google.com/calendar/u/0?cid=ZDVhMWNiMzViZjcwNDU2MWRkZTNkMzQ0NjVlNzU3Y2Y4ZWIzMmFmODc5ZmEwNTUzZjczZjJlYzA1ZmE0MzM5Y0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+- [Meeting Link](https://zoom.us/j/93170416153?pwd=3IFy7VhwrbqCivQ8jbZIfhDlBU0xAJ.1)
+
+## Leads
+
+Leads are responsible for the overall operation of the SIG, including
+organizing meetings, driving technical discussions, and coordinating follow-up
+actions.
+
+- ZongQing Li ([@zach593](https://github.com/zach593), Trip.com)
+
+## Contact
+
+- CNCF Slack: [#karmada](https://cloud-native.slack.com/archives/C02MUF8QXUN)

--- a/sigs/sig-ui/README.md
+++ b/sigs/sig-ui/README.md
@@ -1,0 +1,34 @@
+# SIG-UI
+
+## Overview
+
+Karmada UI-related design reviews and technical discussions.
+
+## Scope
+
+This SIG focuses on the design, development, and user experience of the Karmada
+Dashboard and related UI components. It is open to all Karmada community
+members. If there is anything you want to discuss, please add an item to the
+meeting agenda.
+
+## Meetings
+
+Regular Community Meeting:
+* Wednesday at 14:30 UTC+8 (Chinese)(biweekly). [Convert to your timezone](https://dateful.com/convert/utc8?t=1430).
+
+Resources:
+- [Meeting Notes and Agenda](https://docs.google.com/document/d/1dX3skCE-QRBWzABq3O9cG7yhIDUWLYWmg7kGq8UHU6s/edit?tab=t.0)
+- [Meeting Calendar](https://calendar.google.com/calendar/embed?src=a71aae8a75e3558a90683596c71382b8195bf7c84cb50e6e75d1a3e64e08480b%40group.calendar.google.com&ctz=Asia%2FShanghai) | [Subscribe](https://calendar.google.com/calendar/u/0?cid=YTcxYWFlOGE3NWUzNTU4YTkwNjgzNTk2YzcxMzgyYjgxOTViZjdjODRjYjUwZTZlNzVkMWEzZTY0ZTA4NDgwYkBncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
+- [Meeting Link](https://zoom.us/j/97070047574?pwd=lXha0Sqngw4mwtmArP1sjsLMMXk34z.1)
+
+## Leads
+
+Leads are responsible for the overall operation of the SIG, including
+organizing meetings, driving technical discussions, and coordinating follow-up
+actions.
+
+- Wenjiang Ding ([@warjiang](https://github.com/warjiang), ByteDance)
+
+## Contact
+
+- CNCF Slack: [#karmada](https://cloud-native.slack.com/archives/C02MUF8QXUN)


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
<!--
Add one of the following kinds:

/kind cleanup
/kind deprecation
/kind documentation
/kind failing-test
/kind flake

-->

**What this PR does / why we need it**:

Karmada's Special Interest Groups(SIGs) were originally initiated by users and contributors who wanted to collaborate on specific technical areas, with support from the broader community. 

Groups such as `SIG-UI` and `SIG-Scalability` have been running effectively for quite some time, giving the community valuable experience in operating focused discussion groups with low overhead. Building on that experience, the community has formalized the SIG governance documented here — to make it easier for new contributors to get involved and to encourage the formation of more such groups as the project grows.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:


