### PR TITLE
Move inactive maintainers to emeritus

### DIFF
--- a/APPROVERS.md
+++ b/APPROVERS.md
@@ -16,13 +16,11 @@ Please keep the below list sorted in ascending order.
 | Chaosi Pan | @chaosi-zju | ByteDance | karmada-io/karmada/karmadactl/ |
 | Chauncey | @chaunceyjiang | DaoCloud | 1. karmada-io/karmada/pkg/controllers<br>2. karmada-io/karmada/pkg/metricsadapter/<br>3. karmada-io/karmada/cmd/metrics-adapter/<br>... |
 | Future | @pidb | AIML INSTITUTE | karmada-io/karmada/charts/ |
-| Hanbo Li | @mrlihanbo | ByteDance | karmada-io/karmada/hack/ |
 | Hongcai Ren | @RainbowMango | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
 | Jinhui Ying | @ikaven1024 | DiDi | 1. karmada-io/karmada/hack/<br>2. karmada-io/karmada/pkg/search/<br>3. karmada-io/karmada/cmd/karmada-search/<br>... |
 | Joe Nathan Abellard | @jabellard | Bloomberg | karmada-io/karmada/operators |
 | Junhua He | @whitewindmills | CECloud | karmada-io/karmada/pkg/scheduler/ |
 | Kevin Wang | @kevin-wangzefeng | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
-| Lei Xue | @carmark | Moore Threads | karmada-io/community |
 | Michael Yao | @windsonsea | DaoCloud | karmada-io/website/i18n/ |
 | Michas Szacillo | @mszacillo | Bloomberg | karmada-io/karmada/controllers, webhook |
 | Prodan | @prodanlabs | Independent | karmada-io/karmada/pkg/karmadactl/cmdinit/ |
@@ -37,8 +35,6 @@ Please keep the below list sorted in ascending order.
 | Wen Jiang | @warjiang | ByteDance | karmada-io/dashboard |
 | Yan Li | @huntsman-li | Hualala | 1. karmada-io/karmada/pkg/search/<br>2. karmada-io/karmada/cmd/karmada-search/ |
 | Yasong Li | @liys87x | Hualala | 1. karmada-io/karmada/pkg/search/<br>2. karmada-io/karmada/cmd/karmada-search/ |
-| Yifan Shen | @zoroyouxi | ICBC | karmada-io/community |
-| Yiheng Ci | @lfbear | Tiger Brokers | karmada-io/karmada/hack/ |
 | Yike Bu | @yike21 | UESTC | karmada-io/karmada/pkg/resourceinterpreter/default/thirdparty/ |
 | Yingjun Wu | @wuyingjun-lucky | China Mobile Cloud | karmada-io/karmada/pkg/karmadactl/addons/ |
 | Yuanpeng Liang | @liangyuanpeng | Yunhorn | karmada-io/karmada/hack/, .github |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,22 +9,24 @@ Please keep the below list sorted in ascending order.
 | Maintainer          | GitHub ID           | Affiliation   | Email                        |
 |---------------------|---------------------|---------------|------------------------------|
 | Ding Wenjiang       | @warjiang           | ByteDance     | <1096409085@qq.com>          |
-| Hanbo Li            | @mrlihanbo          | ByteDance     | <mrlihanbo@gmail.com>        |
 | Hongcai Ren         | @RainbowMango       | Huawei        | <renhongcai@huawei.com>      |
 | Joe Nathan Abellard | @jabellard          | Bloomberg     | <joenatech@gmail.com>        |
 | Junhua He           | @whitewindmills     | CECloud       | <jayfantasyhjh@gmail.com>    |
 | Kevin Wang          | @kevin-wangzefeng   | Huawei        | <wangzefeng@huawei.com>      |
-| Lei Xue             | @carmark            | Moore Threads | <vfs@live.com>               |
 | Michas Szacillo     | @mszacillo          | Bloomberg     | <mszacillo@bloomberg.net>    |
 | Qiangqiang Chang    | @CharlesQQ          | Hello Group   | <charles_ali@qq.com>         |
 | Shiyi Xie           | @GitHubxsy          | Huawei        | <xieshiyi1@huawei.com>       |
 | Wei-Cheng Lai       | @seanlaii           | Bloomberg     | <qazwsx0939059006@gmail.com> |
 | Xiao Zhang          | @wawa0210           | DaoCloud      | <xiao.zhang@daocloud.io>     |
-| Yifan Shen          | @zoroyouxi          | ICBC          | <shenyf@sdc.icbc.com.cn>     |
-| Yiheng Ci           | @lfbear             | Tiger Brokers | <lfbear@gmail.com>           |
 | Zhen Chang          | @XiShanYongYe-Chang | Huawei        | <changzhen5@huawei.com>      |
 | Zhuang Zhang        | @zhzhuang-zju       | Huawei        | <zhangzhuang12@huawei.com>   |
 | Zongqing Li         | @zach593            | Trip.com      | <zach_li@outlook.com>        |
 
 ## Emeritus Maintainers
-Do not have any emeritus maintainers yet.
+
+| Maintainer          | GitHub ID           | Affiliation   | Email                        |
+|---------------------|---------------------|---------------|------------------------------|
+| Hanbo Li            | @mrlihanbo          | ByteDance     | <mrlihanbo@gmail.com>        |
+| Lei Xue             | @carmark            | Moore Threads | <vfs@live.com>               |
+| Yifan Shen          | @zoroyouxi          | ICBC          | <shenyf@sdc.icbc.com.cn>     |
+| Yiheng Ci           | @lfbear             | Tiger Brokers | <lfbear@gmail.com>           |

--- a/OWNERS
+++ b/OWNERS
@@ -1,20 +1,22 @@
+# This OWNERS file is maintained following the Kubernetes Prow convention.
+# See https://www.kubernetes.dev/docs/guide/owners/ for more details.
+#
+# Want to be listed here? We'd love to have you!
+# Start by reviewing PRs, opening issues, and contributing fixes.
+# Active, high-quality contributions are the path to becoming a
+# reviewer and then an approver. See our community membership guide:
+# https://github.com/karmada-io/community/blob/main/community-membership.md
+
 reviewers:
-- carmark
 - GitHubxsy
 - kevin-wangzefeng
-- lfbear
-- mrlihanbo
 - RainbowMango
 - whitewindmills
 - XiShanYongYe-Chang
-- zoroyouxi
+
 approvers:
-- carmark
 - GitHubxsy
 - kevin-wangzefeng
-- lfbear
-- mrlihanbo
 - RainbowMango
 - whitewindmills
 - XiShanYongYe-Chang
-- zoroyouxi

--- a/REVIEWERS.md
+++ b/REVIEWERS.md
@@ -17,7 +17,6 @@ Please keep the below list sorted in ascending order.
 | Chaosi Pan | @chaosi-zju | ByteDance | karmada-io/karmada/karmadactl/ |
 | Chauncey | @chaunceyjiang | DaoCloud | 1. karmada-io/karmada/pkg/controllers<br>2. karmada-io/karmada/pkg/metricsadapter/<br>3. karmada-io/karmada/cmd/metrics-adapter/<br>... |
 | Future | @pidb | AIML INSTITUTE | karmada-io/karmada/charts/ |
-| Hanbo Li | @mrlihanbo | ByteDance | karmada-io/karmada/hack/ |
 | Hongcai Ren | @RainbowMango | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
 | Hui Jiang | @jhnine | Joint Cloud | karmada-io/dashboard |
 | Ihor Sychevskyi | @Arhell | Phalcon | karmada-io/website |
@@ -27,7 +26,6 @@ Please keep the below list sorted in ascending order.
 | Junhua He | @whitewindmills | CECloud | karmada-io/karmada/pkg/scheduler/ |
 | Jun Qian | @qianjun1993 | Tencent | karmada-io/karmada/pkg/scheduler/ |
 | Kevin Wang | @kevin-wangzefeng | Huawei | 1. karmada-io/karmada<br>2. karmada-io/website |
-| Lei Xue | @carmark | Moore Threads | karmada-io/community |
 | Michael Yao | @windsonsea | DaoCloud | karmada-io/website/i18n/ |
 | Michas Szacillo | @mszacillo | Bloomberg | karmada-io/karmada/controllers, webhook |
 | Prodan | @prodanlabs | Independent | karmada-io/karmada/pkg/karmadactl/cmdinit/ |
@@ -49,8 +47,6 @@ Please keep the below list sorted in ascending order.
 | Yangfeng Huang | @yanfeng1992 | CECloud | karmada-io/karmada/pkg/karmadactl |
 | Yan Li | @huntsman-li | Hualala | 1. karmada-io/karmada/pkg/search/<br>2. karmada-io/karmada/cmd/karmada-search/ |
 | Yasong Li | @liys87x | Hualala | 1. karmada-io/karmada/pkg/search/<br>2. karmada-io/karmada/cmd/karmada-search/ |
-| Yifan Shen | @zoroyouxi | ICBC | karmada-io/community |
-| Yiheng Ci | @lfbear | Tiger Brokers | karmada-io/karmada/hack/ |
 | Yike Bu | @yike21 | UESTC | karmada-io/karmada/pkg/resourceinterpreter/default/thirdparty/ |
 | Yingjun Wu | @wuyingjun-lucky | China Mobile Cloud | karmada-io/karmada/pkg/karmadactl/addons/ |
 | Yuanpeng Liang | @liangyuanpeng | Yunhorn | karmada-io/karmada/hack/ |

--- a/github-config/config.yaml
+++ b/github-config/config.yaml
@@ -26,12 +26,9 @@ teams:
   - kevin-wangzefeng
   - RainbowMango
   members:
-  - carmark
   - CharlesQQ
   - GitHubxsy
   - jabellard
-  - lfbear
-  - mrlihanbo
   - mszacillo
   - seanlaii
   - warjiang
@@ -40,7 +37,6 @@ teams:
   - XiShanYongYe-Chang
   - zach593
   - zhzhuang-zju
-  - zoroyouxi
 - name: repo-admins
   maintainers:
   - kevin-wangzefeng


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR moves the following four maintainers from Active Maintainers to Emeritus Maintainers:
- Hanbo Li (@mrlihanbo)
- Lei Xue (@carmark)
- Yifan Shen (@zoroyouxi)
- Yiheng Ci (@lfbear)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I talked to them individually, and they are currently unable to continue their day-to-day maintenance work. To keep the maintainer list an accurate reflection of who is actively maintaining the project today, we are moving them to the Emeritus list per our community convention. And they are more than welcome to return whenever they are ready. 

