### PR TITLE
refactor: extract meeting details into a dedicated MEETINGS.md file

### DIFF
--- a/MEETINGS.md
+++ b/MEETINGS.md
@@ -1,0 +1,20 @@
+# Meetings
+
+## Community Meeting
+
+Regular Community Meeting:
+* Tuesday at 14:30 UTC+8 (Chinese)(biweekly). [Convert to your timezone](https://dateful.com/convert/utc8?t=1430).
+* Tuesday at 15:00 UTC+0 (English)(biweekly). [Convert to your timezone](https://dateful.com/convert/coordinated-universal-time-utc?t=15).
+
+Resources:
+- [Meeting Notes and Agenda](https://docs.google.com/document/d/1y6YLVC-v7cmVAdbjedoyR5WL0-q45DBRXTvz5_I7bkA/edit)
+- [Meeting Calendar](https://calendar.google.com/calendar/embed?src=karmadaoss%40gmail.com&ctz=Asia%2FShanghai) | [Subscribe](https://calendar.google.com/calendar/u/1?cid=a2FybWFkYW9zc0BnbWFpbC5jb20)
+- [Meeting Link](https://zoom.com/my/karmada)
+
+## SIG Meetings
+
+[Special Interest Groups (SIGs)](sigs/README.md) hold their own meetings to discuss topics within their scope. For the
+latest meeting information, including schedule, agenda, notes, and other details, please refer to each SIG page:
+
+- [SIG-UI](sigs/sig-ui/README.md)
+- [SIG-Scalability](sigs/sig-scalability/README.md)

--- a/README.md
+++ b/README.md
@@ -3,24 +3,9 @@ Welcome to Karmada Community!
 
 This is the starting point for becoming a contributor - improving code, improving docs, giving talks, etc.
 
-## Community Meeting
+## Meetings
 
-Regular Community Meeting:
-* Tuesday at 14:30 UTC+8 (Chinese)(biweekly). [Convert to your timezone](https://dateful.com/convert/utc8?t=1430).
-* Tuesday at 15:00 UTC+0 (English)(biweekly). [Convert to your timezone](https://dateful.com/convert/coordinated-universal-time-utc?t=15).
-
-Resources:
-- [Meeting Notes and Agenda](https://docs.google.com/document/d/1y6YLVC-v7cmVAdbjedoyR5WL0-q45DBRXTvz5_I7bkA/edit)
-- [Meeting Calendar](https://calendar.google.com/calendar/embed?src=karmadaoss%40gmail.com&ctz=Asia%2FShanghai) | [Subscribe](https://calendar.google.com/calendar/u/1?cid=a2FybWFkYW9zc0BnbWFpbC5jb20)
-- [Meeting Link](https://zoom.com/my/karmada)
-
-## SIG Meetings
-
-[Special Interest Groups (SIGs)](sigs/README.md) hold their own meetings to discuss topics within their scope. For the
-latest meeting information, including schedule, agenda, notes, and other details, please refer to each SIG page:
-
-- [SIG-UI](sigs/sig-ui/README.md)
-- [SIG-Scalability](sigs/sig-scalability/README.md)
+Information about Community Meetings and SIG Meetings has been moved to [MEETINGS.md](MEETINGS.md).
 
 ## Contact
 


### PR DESCRIPTION
## Description
This PR moves the detailed Community and SIG meeting information from the main `README.md` into a dedicated `MEETINGS.md` file.
## Motivation
As the community grows, the main `README.md` can become bloated with specific operational details. Extracting the meeting schedules and links into a dedicated `MEETINGS.md` file improves the readability of the root README while keeping the meeting information easily accessible.
## Changes
- `README.md`: Removed the verbose "Community Meeting" and "SIG Meetings" sections, replacing them with a concise link to `MEETINGS.md`.
- `MEETINGS.md`: Created this new file containing the relocated meeting details.
## Testing
- [x] Verified that `MEETINGS.md` renders correctly.
- [x] Verified that the link from `README.md` to `MEETINGS.md` works properly.
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
Signed-off-by: Author Name : saiashok103@gmail.com